### PR TITLE
allow empty startval

### DIFF
--- a/src/main/resources/io/jenkins/plugins/json_editor_parameter/JsonEditorParameterDefinition/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/json_editor_parameter/JsonEditorParameterDefinition/config.jelly
@@ -13,7 +13,7 @@
   </f:entry>
 
   <f:entry title='Start Values' field='startval'>
-    <f:textarea default='{}'/>
+    <f:textarea/>
   </f:entry>
 
   <f:entry title='Options' field='options'>

--- a/src/main/resources/io/jenkins/plugins/json_editor_parameter/JsonEditorParameterDefinition/help-startval.html
+++ b/src/main/resources/io/jenkins/plugins/json_editor_parameter/JsonEditorParameterDefinition/help-startval.html
@@ -1,3 +1,4 @@
 <div>
-    The initial values for the JsonEditor form. This value should be valid against the schema.
+    The initial values for the JsonEditor form. This value should be valid against the schema.<br/>
+    Leave empty to use the defaults from the schema.
 </div>


### PR DESCRIPTION
The current implementation makes it impossible to make use of default values defined in the schema. This has also the negative side effect that when an empty json is given with `{}` the editor will hide empty fields by default which leads to a page with no inputs and just some buttons.

The PR allows to use an empty string for the startval and thus the mentioned problems are avoided.

fixes #13

<!-- Please describe your pull request here. -->

### Testing done
manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
