### PR TITLE
expose parameter as environment variables

### DIFF
--- a/src/main/java/io/jenkins/plugins/json_editor_parameter/JsonEditorParameterValue.java
+++ b/src/main/java/io/jenkins/plugins/json_editor_parameter/JsonEditorParameterValue.java
@@ -1,6 +1,9 @@
 package io.jenkins.plugins.json_editor_parameter;
 
+import hudson.EnvVars;
 import hudson.model.ParameterValue;
+import hudson.model.Run;
+import java.util.Locale;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -15,6 +18,12 @@ public class JsonEditorParameterValue extends ParameterValue {
     public JsonEditorParameterValue(String name, String value) {
         super(name);
         this.json = value;
+    }
+
+    @Override
+    public void buildEnvironment(Run<?, ?> build, EnvVars env) {
+        env.put(name, json);
+        env.put(name.toUpperCase(Locale.ENGLISH), json); // backward compatibility pre 1.345
     }
 
     @Override


### PR DESCRIPTION
to be able to use the json editor parameter in freestyle jobs and to have direct access in `sh` steps in pipelines the values should be exposed as environment variables

fixes #14 
<!-- Please describe your pull request here. -->

### Testing done
manual testing
create freestyle job and configure a json editor parameter and a shell step that makes use of the parameter

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
